### PR TITLE
make getFQDN publicly available

### DIFF
--- a/fqdn.go
+++ b/fqdn.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 )
 
+// GetFQDN uses /bin/hostname to get the fqdn for the host
 func GetFQDN() string {
 	// #nosec
 	out, err := exec.Command("/bin/hostname", "-f").Output()

--- a/fqdn.go
+++ b/fqdn.go
@@ -5,7 +5,7 @@ import (
 	"os/exec"
 )
 
-func getFQDN() string {
+func GetFQDN() string {
 	// #nosec
 	out, err := exec.Command("/bin/hostname", "-f").Output()
 	if err != nil {

--- a/service.go
+++ b/service.go
@@ -202,7 +202,7 @@ func (s *Service) buildCommand() *cobra.Command {
 		// configure tracker
 		s.Tracker.EventMetadata.Service = s.Name
 		s.Tracker.EventMetadata.Environment = env.Env
-		s.Tracker.EventMetadata.Host = getFQDN()
+		s.Tracker.EventMetadata.Host = GetFQDN()
 		s.Tracker.EventMetadata.Release = CodeVersion
 
 		sarama.Logger = &saramaLoggerWrapper{


### PR DESCRIPTION
old `rex.GetFQDN` is used by `bidder`. no harm in making it public in `go-service` too, is there?