### PR TITLE
remove timestamp from exported metrics

### DIFF
--- a/metrics-prom_test.go
+++ b/metrics-prom_test.go
@@ -12,7 +12,7 @@ func TestPrometheusMetrics_Update(t *testing.T) {
 	t.Run(`empty`, func(t *testing.T) {
 		r := metrics.NewRegistry()
 		p := service.NewPrometheusMetrics(r, "test")
-		assert.NoError(t, p.Update(2000))
+		assert.NoError(t, p.Update())
 
 		assert.Equal(t, ``, p.String())
 	})
@@ -28,64 +28,64 @@ func TestPrometheusMetrics_Update(t *testing.T) {
 		metrics.GetOrRegisterCounter("app,label1=1,label2=2 c1", r).Inc(2)
 
 		p := service.NewPrometheusMetrics(r, "test")
-		assert.NoError(t, p.Update(2000))
+		assert.NoError(t, p.Update())
 
 		assert.Equal(t, `
 # TYPE app_c1_total counter
-app_c1_total{service="test",l1="2"} 0 2000
-app_c1_total{service="test",label1="1",label2="2"} 2 2000
+app_c1_total{service="test",l1="2"} 0
+app_c1_total{service="test",label1="1",label2="2"} 2
 
 # TYPE app_c2_total counter
-app_c2_total{service="test"} 3 2000
+app_c2_total{service="test"} 3
 
 # TYPE app_g1 gauge
-app_g1{service="test",l1="1"} 0 2000
-app_g1{service="test",l1="2"} 0 2000
+app_g1{service="test",l1="1"} 0
+app_g1{service="test",l1="2"} 0
 
 # TYPE app_h1 summary
-app_h1_count{service="test",l1="1"} 0 2000
-app_h1_sum{service="test",l1="1"} 0 2000
-app_h1{service="test",l1="1",quantile="0.5"} 0 2000
-app_h1{service="test",l1="1",quantile="0.75"} 0 2000
-app_h1{service="test",l1="1",quantile="0.95"} 0 2000
-app_h1{service="test",l1="1",quantile="0.99"} 0 2000
-app_h1{service="test",l1="1",quantile="0.999"} 0 2000
+app_h1_count{service="test",l1="1"} 0
+app_h1_sum{service="test",l1="1"} 0
+app_h1{service="test",l1="1",quantile="0.5"} 0
+app_h1{service="test",l1="1",quantile="0.75"} 0
+app_h1{service="test",l1="1",quantile="0.95"} 0
+app_h1{service="test",l1="1",quantile="0.99"} 0
+app_h1{service="test",l1="1",quantile="0.999"} 0
 
 # TYPE app_h1_max gauge
-app_h1_max{service="test",l1="1"} 0 2000
+app_h1_max{service="test",l1="1"} 0
 
 # TYPE app_h1_mean gauge
-app_h1_mean{service="test",l1="1"} 0 2000
+app_h1_mean{service="test",l1="1"} 0
 
 # TYPE app_h1_min gauge
-app_h1_min{service="test",l1="1"} 0 2000
+app_h1_min{service="test",l1="1"} 0
 
 # TYPE app_h1_stddev gauge
-app_h1_stddev{service="test",l1="1"} 0 2000
+app_h1_stddev{service="test",l1="1"} 0
 
 # TYPE app_m1_total counter
-app_m1_total{service="test",l1="1"} 0 2000
+app_m1_total{service="test",l1="1"} 0
 
 # TYPE app_t1 summary
-app_t1_count{service="test"} 0 2000
-app_t1_sum{service="test"} 0 2000
-app_t1{service="test",quantile="0.5"} 0 2000
-app_t1{service="test",quantile="0.75"} 0 2000
-app_t1{service="test",quantile="0.95"} 0 2000
-app_t1{service="test",quantile="0.99"} 0 2000
-app_t1{service="test",quantile="0.999"} 0 2000
+app_t1_count{service="test"} 0
+app_t1_sum{service="test"} 0
+app_t1{service="test",quantile="0.5"} 0
+app_t1{service="test",quantile="0.75"} 0
+app_t1{service="test",quantile="0.95"} 0
+app_t1{service="test",quantile="0.99"} 0
+app_t1{service="test",quantile="0.999"} 0
 
 # TYPE app_t1_max gauge
-app_t1_max{service="test"} 0 2000
+app_t1_max{service="test"} 0
 
 # TYPE app_t1_mean gauge
-app_t1_mean{service="test"} 0 2000
+app_t1_mean{service="test"} 0
 
 # TYPE app_t1_min gauge
-app_t1_min{service="test"} 0 2000
+app_t1_min{service="test"} 0
 
 # TYPE app_t1_stddev gauge
-app_t1_stddev{service="test"} 0 2000
+app_t1_stddev{service="test"} 0
 `, p.String())
 	})
 	t.Run("counter", func(t *testing.T) {
@@ -95,15 +95,15 @@ app_t1_stddev{service="test"} 0 2000
 		metrics.GetOrRegisterCounter("app,l1=2 with_label", r).Inc(5)
 
 		p := service.NewPrometheusMetrics(r, "test")
-		assert.NoError(t, p.Update(2000))
+		assert.NoError(t, p.Update())
 
 		assert.Equal(t, `
 # TYPE app_no_label_total counter
-app_no_label_total{service="test"} 2 2000
+app_no_label_total{service="test"} 2
 
 # TYPE app_with_label_total counter
-app_with_label_total{service="test",l1="1"} 4 2000
-app_with_label_total{service="test",l1="2"} 5 2000
+app_with_label_total{service="test",l1="1"} 4
+app_with_label_total{service="test",l1="2"} 5
 `, p.String())
 	})
 	for _, td := range [][4]string{
@@ -136,7 +136,7 @@ app_with_label_total{service="test",l1="2"} 5 2000
 			r := metrics.NewRegistry()
 			p := service.NewPrometheusMetrics(r, "test")
 			metrics.GetOrRegisterCounter(td[1], r)
-			assert.EqualError(t, p.Update(2000), td[2])
+			assert.EqualError(t, p.Update(), td[2])
 			assert.Equal(t, td[3], p.String())
 		})
 

--- a/metrics.go
+++ b/metrics.go
@@ -281,7 +281,7 @@ func (s *Executor) flushMetrics(freq time.Duration) {
 		metrics.DefaultRegistry.Each(func(name string, i interface{}) {
 			s.flushMetric(name, i, ts, writeCb)
 		})
-		if flushErr := s.promMetrics.Update(time.Now().Unix()); flushErr != nil {
+		if flushErr := s.promMetrics.Update(); flushErr != nil {
 			s.Log.Warnf("failures while collect metrics: %v", flushErr)
 		}
 	}


### PR DESCRIPTION
On scraping, we see the error:

> Error on ingesting samples that are too old or are too far into the future

It's also recommended to omit the timestamp when scraping, see https://groups.google.com/forum/#!topic/prometheus-users/NvLGxFZczJk.
