### PR TITLE
revert dependencies to pre-go-mod versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/remerge/go-env v0.0.0-20190107192038-3e5082146037
 	github.com/remerge/go-lock_free_timer v0.0.0-20181129173822-9894c16a08a7
 	github.com/remerge/go-timestr v0.0.0-20180605143718-e115f77d6e01 // indirect
-	github.com/remerge/go-tracker v0.0.0-20190401124940-3f21a08efa66
+	github.com/remerge/go-tracker v0.0.0-20181221184943-fa24003c5f7d
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/stretchr/testify v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/remerge/go-service
 
-go 1.12
-
 require (
 	cloud.google.com/go v0.38.0
 	github.com/Shopify/sarama v1.22.1


### PR DESCRIPTION
downgrade `go-tracker` due a bug.